### PR TITLE
Don't send rows until client acknowledges subscription to our event

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,47 +14,9 @@ $ cd target/pack
 $ bin/affqis
 ```
 
-Here's an ugly hacked together example of chatting with the server using node + coffee + autobahn:
-
-```coffee
-autobahn = require 'autobahn'
-
-connection = new autobahn.Connection(url: "ws://localhost:8080/affqis", realm: "hive")
-
-connection.onopen = (session) ->
-  connectionId = null
-  session.call('connect', ["myuser", "my.hiveserver.com", 10000])
-   .then((id) =>
-     connectionId = id
-     console.log("Connection id: #{id}")
-     session.call('execute', [id, "select * from aschema.atable limit 10"]))
-   .then((id) =>
-     console.log("Execution id: #{id}")
-     session.subscribe(id, (args) =>
-       if args[0] == "finished"
-         console.log "Done streaming results, closing connection #{connectionId}"
-         session.call('disconnect', [connectionId]).then(console.log)
-       else
-         console.log(JSON.parse(args[1]))))
-
-console.log("Connecting...")
-connection.open()
-```
-
-And here's what the glorious output of such a thing might be:
+You can configure the netty server with environment variables:
 
 ```
-Connecting...
-Connection id: a259c6dd-793e-4408-93c5-9d094f546000
-Execution id: execution.e843a88d_7dba_4e0f_91d5_aa12cf76e6a0
-[ { value: 5, type: 'int', name: 'atable.id' },
-  { value: 1, type: 'int', name: 'atable.game_id' },
-  { value: 76168, type: 'int', name: 'atable.user_id' },
-  ... and so on for each column ...]
-[... next row and so on for each ...]
-
-Done streaming results, closing connection a259c6dd-793e-4408-93c5-9d094f546000
-true
+HOST=0.0.0.0
+PORT=8080
 ```
-
-Easy, right?


### PR DESCRIPTION
Otherwise there's a race condition, because the client may not
subscribe until after our events get fired at which point they are lost
to the nethers.